### PR TITLE
Add stereo output test and flashing feedback

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -366,10 +366,20 @@
             margin-bottom: 8px;
         }
 
-        .current-selection-name {
-            color: #333;
-            font-size: 16px;
-        }
+.current-selection-name {
+    color: #333;
+    font-size: 16px;
+}
+
+/* Flash animation for device test warnings */
+@keyframes flash-bg {
+    0%, 100% { background-color: transparent; }
+    50% { background-color: #ffeaa7; }
+}
+
+.flash {
+    animation: flash-bg 0.5s ease-in-out 0s 4;
+}
 
         @media (max-width: 768px) {
             .breathing-monitor {


### PR DESCRIPTION
## Summary
- implement flashing animation for troubleshooting device tests
- add stereo output test with left and right channel beeps
- improve `testDevice()` to show microphone result and play stereo test

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6850e0c90d3883269078358d4ae6c8c8