### PR TITLE
Localize index text

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,79 +3,77 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>智能呼吸拍頻處理器</title>
+    <title></title>
     <link rel="stylesheet" href="assets/base.css">
 </head>
 <body>
     <div class="container">
-        <h1>🧘 每天3分鐘，vuko time，轉動生命的每一天</h1>
+        <h1 id="mainTitle"></h1>
         
         <div class="adaptive-mode">
-            <h3>🤖 使用說明</h3>
+            <h3></h3>
             <ul>
-                <li>請使用<strong>雙聲道耳機</strong>，這樣才能達成腦中拍頻的效果。</li>
-                <li>若您同意使用您的<strong>麥克風</strong>，我們會嘗試監測狀態，引導你進入不同的狀態。</li>
+                <li id="instructionHeadphones"></li>
+                <li id="instructionMicrophone"></li>
             </ul>
         </div>
 
         <div class="config-audio-container">
             <div class="audio-search-section">
-                <h4 id="audioSearchTitle">🎵 背景音樂搜尋</h4>
+                <h4 id="audioSearchTitle"></h4>
                 <div class="search-container">
-                    <input type="text" id="musicSearchInput" class="search-input" placeholder="搜尋音樂... (例如: 森林、海浪、冥想)">
+                    <input type="text" id="musicSearchInput" class="search-input" placeholder="">
                 </div>
                 <div id="currentSelection" class="current-selection" style="display: none;">
-                    <div class="current-selection-label" id="currentSelectionLabel">目前選擇</div>
+                    <div class="current-selection-label" id="currentSelectionLabel"></div>
                     <div class="current-selection-name" id="currentSelectionName"></div>
                 </div>
                 <div id="searchResults" class="search-results" style="display: none;"></div>
             </div>
 
             <div class="config-info">
-                <h4 id="systemConfigTitle">🔧 系統配置</h4>
+                <h4 id="systemConfigTitle"></h4>
                 <div class="config-item">
-                    <span>基頻頻率：</span>
+                    <span id="baseFreqLabel"></span>
                     <span id="configBaseFreq">200 Hz</span>
                 </div>
                 <div class="config-item">
-                    <span>背景音檔：</span>
+                    <span id="audioFileLabel"></span>
                     <span id="configAudioFile">無</span>
                 </div>
                 <div class="config-item">
-                    <span>音量比例：</span>
-                    <span>拍頻 30% / 背景音 70%</span>
+                    <span id="volumeRatioLabel"></span>
+                    <span id="configVolumeRatio"></span>
                 </div>
-                <button onclick="testDevice()" class="device-test-btn" id="deviceTestBtn">
-                    🎤 設備測試
-                </button>
+                <button onclick="testDevice()" class="device-test-btn" id="deviceTestBtn"></button>
             </div>
         </div>
 
         <div class="breathing-monitor">
             <div class="breath-visual">
-                <h3>呼吸視覺化</h3>
+                <h3></h3>
                 <canvas id="waveform" class="waveform"></canvas>
             </div>
 
             <div class="breath-stats">
-                <h3>即時數據</h3>
+                <h3></h3>
                 <div class="stat-item">
-                    <span class="stat-label">呼吸速率：</span>
-                    <span class="stat-value" id="breathRate">-- 次/分</span>
+                    <span class="stat-label"></span>
+                    <span class="stat-value" id="breathRate">--</span>
                 </div>
                 <div class="stat-item">
-                    <span class="stat-label">當前狀態：</span>
-                    <span class="stat-value" id="currentState">待檢測</span>
+                    <span class="stat-label"></span>
+                    <span class="stat-value" id="currentState"></span>
                 </div>
                 <div class="stat-item">
-                    <span class="stat-label">腦波類型：</span>
+                    <span class="stat-label"></span>
                     <span class="stat-value" id="brainwaveType">--</span>
                 </div>
             </div>
         </div>
 
         <div class="control-buttons">
-            <button onclick="toggleAdaptiveMode()" id="monitorToggleBtn">🎶 開始</button>
+            <button onclick="toggleAdaptiveMode()" id="monitorToggleBtn"></button>
         </div>
 
         <div id="status" class="status" style="display: none;"></div>

--- a/js/app.js
+++ b/js/app.js
@@ -406,17 +406,18 @@
         function updateLanguageContent() {
             const content = getLanguageContent();
             
-            // 更新主要標題
+            // 更新主要標題與頁面標題
+            document.title = content.title;
             document.querySelector('h1').textContent = content.title;
             document.querySelector('.adaptive-mode h3').textContent = content.subtitle;
-            document.querySelector('.adaptive-mode p').textContent = content.description;
-            
-            // 更新狀態描述
-            const listItems = document.querySelectorAll('.adaptive-mode li');
-            listItems[0].innerHTML = `<strong>${content.states.deep_relaxed}</strong> ${content.stateDescriptions.deep_relaxed}`;
-            listItems[1].innerHTML = `<strong>${content.states.relaxed}</strong> ${content.stateDescriptions.relaxed}`;
-            listItems[2].innerHTML = `<strong>${content.states.normal}</strong> ${content.stateDescriptions.normal}`;
-            listItems[3].innerHTML = `<strong>${content.states.tense}</strong> ${content.stateDescriptions.tense}`;
+
+            // 更新使用說明
+            const headphoneItem = document.getElementById('instructionHeadphones');
+            const micItem = document.getElementById('instructionMicrophone');
+            if (headphoneItem && micItem && content.instructions) {
+                headphoneItem.innerHTML = content.instructions.headphones;
+                micItem.innerHTML = content.instructions.microphone;
+            }
             
             // 更新配置區域
             document.getElementById('systemConfigTitle').textContent = content.labels.systemConfig;
@@ -427,6 +428,11 @@
             
             // 更新設備測試按鈕
             document.getElementById('deviceTestBtn').innerHTML = `🎤 ${content.labels.deviceTest}`;
+
+            // 配置標籤
+            document.getElementById('baseFreqLabel').textContent = content.labels.baseFreq;
+            document.getElementById('audioFileLabel').textContent = content.labels.audioFile;
+            document.getElementById('volumeRatioLabel').textContent = content.labels.volumeRatio;
             
             // 更新標籤
             document.querySelector('.breath-visual h3').textContent = content.labels.breathVisual;
@@ -473,8 +479,19 @@
         function initConfigDisplay() {
             const content = getLanguageContent();
             const audioUrl = getBackgroundAudioUrl();
-            
+
             document.getElementById('configBaseFreq').textContent = `${CONFIG.BASE_FREQUENCY} ${content.units.hz}`;
+
+            const binauralPct = Math.round(CONFIG.BINAURAL_VOLUME * 100);
+            const bgPct = Math.round((1 - CONFIG.BINAURAL_VOLUME) * 100);
+            if (content.volumeRatioDetail) {
+                document.getElementById('configVolumeRatio').textContent =
+                    content.volumeRatioDetail
+                        .replace('{binaural}', binauralPct)
+                        .replace('{background}', bgPct);
+            } else {
+                document.getElementById('configVolumeRatio').textContent = `${binauralPct}% / ${bgPct}%`;
+            }
             
             // 顯示音樂類型和國家資訊
             let audioInfo = content.units.none;

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -27,6 +27,11 @@
                     normal: '(15-20次/分)：Alpha波 10Hz - 專注與平靜',
                     tense: '(&gt;20次/分)：Beta波 14Hz - 提升專注力'
                 },
+                instructions: {
+                    headphones: '請使用<strong>雙聲道耳機</strong>，這樣才能達成腦中拍頻的效果。',
+                    microphone: '若您同意使用您的<strong>麥克風</strong>，我們會嘗試監測狀態，引導你進入不同的狀態。'
+                },
+                volumeRatioDetail: '拍頻 {binaural}% / 背景音 {background}%',
                 labels: {
                     breathRate: '呼吸速率：',
                     currentState: '當前狀態：',
@@ -83,6 +88,11 @@
                     normal: '(15-20次/分)：Alpha波 10Hz - 专注与平静',
                     tense: '(&gt;20次/分)：Beta波 14Hz - 提升专注力'
                 },
+                instructions: {
+                    headphones: '请使用<strong>双声道耳机</strong>，这样才能达成脑中拍频的效果。',
+                    microphone: '若您同意使用您的<strong>麦克风</strong>，我们会尝试监测状态，引导你进入不同的状态。'
+                },
+                volumeRatioDetail: '拍频 {binaural}% / 背景音 {background}%',
                 labels: {
                     breathRate: '呼吸速率：',
                     currentState: '当前状态：',
@@ -139,6 +149,11 @@
                     normal: '(15-20/min): Alpha 10Hz - Focus & calm',
                     tense: '(&gt;20/min): Beta 14Hz - Enhanced concentration'
                 },
+                instructions: {
+                    headphones: 'Please use <strong>stereo headphones</strong> to achieve the binaural effect.',
+                    microphone: 'If you allow the use of your <strong>microphone</strong>, we will attempt to monitor your state and guide you.'
+                },
+                volumeRatioDetail: 'Binaural {binaural}% / Background {background}%',
                 labels: {
                     breathRate: 'Breath Rate:',
                     currentState: 'Current State:',
@@ -195,6 +210,11 @@
                     normal: '(15-20回/分)：アルファ波 10Hz - 集中と平静',
                     tense: '(&gt;20回/分)：ベータ波 14Hz - 集中力向上'
                 },
+                instructions: {
+                    headphones: '<strong>ステレオヘッドホン</strong>を使用すると、脳内ビート効果が得られます。',
+                    microphone: '<strong>マイク</strong>の使用を許可すると、状態をモニタリングして導きます。'
+                },
+                volumeRatioDetail: 'バイノーラル {binaural}% / 背景音 {background}%',
                 labels: {
                     breathRate: '呼吸数：',
                     currentState: '現在の状態：',
@@ -251,6 +271,11 @@
                     normal: '(15-20회/분): 알파파 10Hz - 집중과 평온',
                     tense: '(&gt;20회/분): 베타파 14Hz - 집중력 향상'
                 },
+                instructions: {
+                    headphones: '<strong>스테레오 헤드폰</strong>을 사용해야 두뇌 비트 효과를 얻을 수 있습니다.',
+                    microphone: '<strong>마이크</strong> 사용을 허용하면 상태를 모니터링하여 안내합니다.'
+                },
+                volumeRatioDetail: '바이노럴 {binaural}% / 배경음 {background}%',
                 labels: {
                     breathRate: '호흡 속도:',
                     currentState: '현재 상태:',
@@ -307,6 +332,11 @@
                     normal: '(15-20/min): Alpha 10Hz - Enfoque y calma',
                     tense: '(>20/min): Beta 14Hz - Mayor concentración'
                 },
+                instructions: {
+                    headphones: 'Por favor utiliza <strong>auriculares estéreo</strong> para lograr el efecto binaural.',
+                    microphone: 'Si permites el uso de tu <strong>micrófono</strong>, intentaremos monitorizar tu estado y guiarte.'
+                },
+                volumeRatioDetail: 'Binaural {binaural}% / Fondo {background}%',
                 labels: {
                     breathRate: 'Frecuencia respiratoria:',
                     currentState: 'Estado actual:',
@@ -363,6 +393,11 @@
                     normal: '(15-20/min): Alpha 10Hz - Foco e calma',
                     tense: '(>20/min): Beta 14Hz - Concentração aprimorada'
                 },
+                instructions: {
+                    headphones: 'Por favor use <strong>fones de ouvido estéreo</strong> para alcançar o efeito binaural.',
+                    microphone: 'Se permitir o uso do seu <strong>microfone</strong>, tentaremos monitorar seu estado e orientá-lo.'
+                },
+                volumeRatioDetail: 'Binaural {binaural}% / Fundo {background}%',
                 labels: {
                     breathRate: 'Taxa de respiração:',
                     currentState: 'Estado atual:',


### PR DESCRIPTION
## Summary
- replace static strings in index.html with placeholders
- add instruction and volume ratio translations to i18n
- populate DOM text from i18n in app.js
- compute dynamic volume ratio from config

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6850e1b1c3f08326b4cefa1a55e2ecad