### PR TITLE
Fix unused state UI

### DIFF
--- a/i18n/zh-tw.json
+++ b/i18n/zh-tw.json
@@ -9,9 +9,6 @@
   "volumeRatioDetail": "拍頻 {binaural}% / 背景音 {background}%",
   "labels": {
     "breathRate": "呼吸速率：",
-    "currentState": "當前狀態：",
-    "beatFreq": "拍頻頻率：",
-    "brainwave": "腦波類型：",
     "baseFreq": "基頻頻率：",
     "audioFile": "背景音檔：",
     "volumeRatio": "音量比例：",
@@ -39,11 +36,5 @@
     "perMin": "次/分",
     "hz": "Hz",
     "none": "無"
-  },
-  "waves": {
-    "delta": "Delta波",
-    "theta": "Theta波",
-    "alpha": "Alpha波",
-    "beta": "Beta波"
   }
 }

--- a/index.html
+++ b/index.html
@@ -61,14 +61,6 @@
                     <span class="stat-label"></span>
                     <span class="stat-value" id="breathRate">--</span>
                 </div>
-                <div class="stat-item">
-                    <span class="stat-label"></span>
-                    <span class="stat-value" id="currentState"></span>
-                </div>
-                <div class="stat-item">
-                    <span class="stat-label"></span>
-                    <span class="stat-value" id="brainwaveType">--</span>
-                </div>
             </div>
         </div>
 

--- a/js/app.js
+++ b/js/app.js
@@ -57,14 +57,6 @@
             }
         }
 
-        // 拍頻配置對應表
-        const BEAT_FREQUENCY_MAP = {
-            'deep_relaxed': 4,    // 深度放鬆 - Delta波
-            'relaxed': 6,         // 放鬆狀態 - Theta波  
-            'normal': 10,         // 正常狀態 - Alpha波
-            'tense': 14           // 緊張狀態 - Beta波
-        };
-
         // ===== 配置區域結束 =====
 
         let audioContext;
@@ -589,7 +581,8 @@
             const content = getLanguageContent();
             const toggleBtn = document.getElementById('monitorToggleBtn');
             toggleBtn.textContent = content.buttons.start;
-            document.getElementById('breathCircle').classList.remove('breathing');
+            const breathCircle = document.getElementById('breathCircle');
+            if (breathCircle) breathCircle.classList.remove('breathing');
 
             // 重置統計顯示
             resetStatsDisplay();
@@ -750,32 +743,24 @@
         // 更新呼吸統計
         function updateBreathingStats(breathRate) {
             const content = getLanguageContent();
-            document.getElementById('breathRate').textContent = `${breathRate.toFixed(1)} ${content.units.perMin}`;
-            
-            let state, beatFreq, brainwave, stateKey;
-            
+            const units = content.units || {};
+            document.getElementById('breathRate').textContent = `${breathRate.toFixed(1)} ${units.perMin || ''}`;
+
+            let beatFreq, stateKey;
+
             if (breathRate < 10) {
-                state = content.states.deep_relaxed;
                 stateKey = 'deep_relaxed';
-                brainwave = content.waves.delta;
+                beatFreq = 4;
             } else if (breathRate < 15) {
-                state = content.states.relaxed;
                 stateKey = 'relaxed';
-                brainwave = content.waves.theta;
+                beatFreq = 6;
             } else if (breathRate < 20) {
-                state = content.states.normal;
                 stateKey = 'normal';
-                brainwave = content.waves.alpha;
+                beatFreq = 10;
             } else {
-                state = content.states.tense;
                 stateKey = 'tense';
-                brainwave = content.waves.beta;
+                beatFreq = 14;
             }
-            
-            beatFreq = BEAT_FREQUENCY_MAP[stateKey];
-            
-            document.getElementById('currentState').textContent = state;
-            document.getElementById('brainwaveType').textContent = brainwave;
             
             // 更新拍頻
             if (beatFreq !== currentBeatFreq) {

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -62,18 +62,21 @@ async function updateLanguageContent() {
     document.getElementById('musicSearchInput').placeholder = labels.searchPlaceholder || '';
     document.getElementById('deviceTestBtn').innerHTML = `🎤 ${labels.deviceTest || ''}`;
 
-    document.getElementById('baseFreqLabel').textContent = labels.baseFreq || '';
-    document.getElementById('audioFileLabel').textContent = labels.audioFile || '';
-    document.getElementById('volumeRatioLabel').textContent = labels.volumeRatio || '';
+    const baseFreqLabel = document.getElementById('baseFreqLabel');
+    if (baseFreqLabel) baseFreqLabel.textContent = labels.baseFreq || '';
+
+    const audioFileLabel = document.getElementById('audioFileLabel');
+    if (audioFileLabel) audioFileLabel.textContent = labels.audioFile || '';
+
+    const volumeRatioLabel = document.getElementById('volumeRatioLabel');
+    if (volumeRatioLabel) volumeRatioLabel.textContent = labels.volumeRatio || '';
 
     document.querySelector('.breath-visual h3').textContent = labels.breathVisual || '';
     document.querySelector('.breath-stats h3').textContent = labels.realTimeData || '';
 
     const statLabels = document.querySelectorAll('.stat-label');
-    if (statLabels.length >= 3) {
+    if (statLabels.length >= 1) {
         statLabels[0].textContent = labels.breathRate || '';
-        statLabels[1].textContent = labels.currentState || '';
-        statLabels[2].textContent = labels.brainwave || '';
     }
 
     const toggleBtn = document.getElementById('monitorToggleBtn');
@@ -86,8 +89,5 @@ async function updateLanguageContent() {
 function resetStatsDisplay() {
     const content = getLanguageContent();
     const units = content.units || {};
-    const status = content.status || {};
     document.getElementById('breathRate').textContent = `-- ${units.perMin || ''}`;
-    document.getElementById('currentState').textContent = status.waiting || '';
-    document.getElementById('brainwaveType').textContent = '--';
 }


### PR DESCRIPTION
## Summary
- remove state/brainwave stats from the page
- stop using state and wave labels in localization
- simplify breathing stats logic

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685119c3a64c8326a7c02e9484963699