### PR TITLE
Add robots.txt allow rule for sitemap

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -7,5 +7,6 @@ Disallow: /img/
 Disallow: /js/
 Disallow: /music/
 Disallow: /config.json
+Allow: /sitemap.xml
 
 Sitemap: https://www.vuko.life/sitemap.xml


### PR DESCRIPTION
## Summary
- allow `/sitemap.xml` in `robots.txt` so crawlers can fetch it

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685278ace3c883268977bbac3bf00cdb