### PR TITLE
Add translation workflow and script

### DIFF
--- a/.github/scripts/translate.py
+++ b/.github/scripts/translate.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import os
+import re
+import time
+from pathlib import Path
+from typing import Any, List, Tuple
+
+import openai
+from babel import Locale
+from tqdm import tqdm
+
+PLACEHOLDER_RE = re.compile(r"{[^{}]+}")
+
+
+def lang_from_path(path: Path) -> str:
+    name = path.stem.lower()
+    if re.fullmatch(r"[a-z]{2}(?:-[a-z]{2})?", name):
+        return name
+    return "zh-tw"
+
+
+def lang_name(code: str) -> str:
+    try:
+        loc = Locale.parse(code)
+        return loc.get_display_name(code)
+    except Exception:
+        return code
+
+
+def load_json(path: Path) -> Any:
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def save_json(path: Path, data: Any) -> None:
+    with path.open("w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+
+def collect_strings(data: Any, path: Tuple = ()) -> List[Tuple[Tuple, str]]:
+    entries: List[Tuple[Tuple, str]] = []
+    if isinstance(data, dict):
+        for k, v in data.items():
+            entries.extend(collect_strings(v, path + (k,)))
+    elif isinstance(data, list):
+        for i, v in enumerate(data):
+            entries.extend(collect_strings(v, path + (i,)))
+    elif isinstance(data, str):
+        entries.append((path, data))
+    return entries
+
+
+def set_value(data: Any, path: Tuple, value: str) -> None:
+    key = path[0]
+    if len(path) == 1:
+        if isinstance(data, list):
+            data[key] = value
+        else:
+            data[key] = value
+        return
+    next_data = data[key]
+    set_value(next_data, path[1:], value)
+
+
+def translate_batch(texts: List[str], src_name: str, tgt_name: str, tgt_code: str) -> List[str]:
+    mapping = {str(i): t for i, t in enumerate(texts)}
+    prompt = (
+        f"Translate the following texts from {src_name} to {tgt_name}. "
+        "Preserve placeholders like {example}. "
+        "Respond ONLY with a JSON object mapping the same numeric keys to the translated texts."
+    )
+    messages = [
+        {"role": "system", "content": "You are a helpful translator."},
+        {"role": "user", "content": prompt + "\n" + json.dumps(mapping, ensure_ascii=False)}
+    ]
+
+    for attempt in range(3):
+        try:
+            resp = openai.ChatCompletion.create(
+                model="gpt-4o",
+                messages=messages,
+                temperature=0
+            )
+            content = resp.choices[0].message.content
+            data = json.loads(content)
+            return [data.get(str(i), texts[i]) for i in range(len(texts))]
+        except Exception as e:
+            print(f"Error during translation ({tgt_code}): {e}; retry {attempt + 1}")
+            time.sleep(2 ** attempt)
+    return texts
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Translate JSON file")
+    parser.add_argument("src", help="source json path")
+    parser.add_argument("dst", help="target json path")
+    args = parser.parse_args()
+
+    openai.api_key = os.getenv("OPENAI_API_KEY")
+
+    src_path = Path(args.src)
+    dst_path = Path(args.dst)
+
+    src_lang = lang_from_path(src_path)
+    dst_lang = lang_from_path(dst_path)
+
+    if src_lang == dst_lang:
+        data = load_json(src_path)
+        save_json(dst_path, data)
+        print(f"Source and target languages are the same ({src_lang}); file copied.")
+        return
+
+    src_name = lang_name(src_lang)
+    tgt_name = lang_name(dst_lang)
+
+    data = load_json(src_path)
+    entries = collect_strings(data)
+
+    batch_size = 20
+    for i in tqdm(range(0, len(entries), batch_size), desc=f"{dst_lang}"):
+        batch = entries[i:i + batch_size]
+        texts = [t for _, t in batch]
+        translated = translate_batch(texts, src_name, tgt_name, dst_lang)
+        for (path, _), trans in zip(batch, translated):
+            set_value(data, path, trans)
+
+    dst_path.parent.mkdir(parents=True, exist_ok=True)
+    save_json(dst_path, data)
+    print(f"Translated {len(entries)} entries to {dst_lang} -> {dst_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/update_translate.yml
+++ b/.github/workflows/update_translate.yml
@@ -1,0 +1,50 @@
+name: Update Translations
+
+on:
+  push:
+    paths:
+      - 'i18n/zh-tw.json'
+      - 'music/base.json'
+      - '.github/scripts/translate.py'
+      - '.github/workflows/update_translate.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  translate:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        lang: [en, es, ja, ko, pt, zh-cn, zh-hk]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Translate i18n to ${{ matrix.lang }}
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          python .github/scripts/translate.py i18n/zh-tw.json i18n/${{ matrix.lang }}.json
+      - name: Translate music to ${{ matrix.lang }}
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          python .github/scripts/translate.py music/base.json music/${{ matrix.lang }}.json
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if [ -n "$(git status --porcelain)" ]; then
+            git add i18n/*.json music/*.json
+            git commit -m "Update translation for ${{ matrix.lang }}"
+            git push
+          fi

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
 sentence-transformers>=2.2.2
+openai>=1.3.0
+Babel>=2.14.0
+tqdm>=4.66.0


### PR DESCRIPTION
## Summary
- add GitHub action to translate `i18n` and `music` json files via OpenAI
- implement translation helper script using GPT‑4o
- update requirements with openai and other dependencies
- switch workflow back to using `zh-tw.json` and remove unused `i18n/base.json`

## Testing
- `python -m py_compile .github/scripts/translate.py`


------
https://chatgpt.com/codex/tasks/task_e_68538a28569083269170d7a571261c05